### PR TITLE
fix: Add watch/list deployment priviliges to prometheus service account

### DIFF
--- a/hpa/prometheus-sa.yaml
+++ b/hpa/prometheus-sa.yaml
@@ -24,10 +24,12 @@ rules:
   resources:
   - deployments
   verbs:
+  - list
   - get
   - create
   - delete
   - patch
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
With the recent change in the controller to wait for the prometheus deployment to become ready
we need to add additional privileges to the prometheus service account.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>