### PR TITLE
feat(elasticsearch): Add trial readiness gate

### DIFF
--- a/elasticsearch/experiment.yaml
+++ b/elasticsearch/experiment.yaml
@@ -37,6 +37,15 @@ spec:
         app: elasticsearch-master
   template: # trial
     spec:
+      readinessGates:
+      - kind: StatefulSet
+        apiVersion: apps/v1
+        name: elasticsearch-master
+        conditionTypes:
+        - redskyops.dev/app-ready
+        InitialDelaySeconds: 5
+        periodSeconds: 5
+        failureThreshold: 30
       setupTasks:
       - name: elasticsearch
         helmChart: elasticsearch


### PR DESCRIPTION
This adds in a trial readiness gate to ensure the elasticsearch
nodes have come up and are available before starting the trial pod.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>