### PR TITLE
Explicitly set pull policy to IfNotPresent

### DIFF
--- a/voting-webapp/application/result-service.yaml
+++ b/voting-webapp/application/result-service.yaml
@@ -37,6 +37,7 @@ spec:
       containers:
       - name: result-service
         image: dockersamples/examplevotingapp_result
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         resources:

--- a/voting-webapp/application/voting-service.yaml
+++ b/voting-webapp/application/voting-service.yaml
@@ -37,6 +37,7 @@ spec:
       containers:
       - name: voting-service
         image: dockersamples/examplevotingapp_vote
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         resources:

--- a/voting-webapp/application/worker.yaml
+++ b/voting-webapp/application/worker.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: worker
         image: dockersamples/examplevotingapp_worker
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             memory: 2000Mi


### PR DESCRIPTION
From [the kube documentation](https://kubernetes.io/docs/concepts/containers/images/#updating-images), the pull policy will be set to always if we do not specify a tag

```
omit the imagePullPolicy and the tag for the image to use.
```

