### PR TITLE
Update READMEs, remove kustomize prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Each example contains additional documentation for usage and describing how it w
 
 <!-- tocstop -->
 
+## Running Experiments
+Each example can be run by executing `kubectl apply -k .` from each of the example directories.
+
 ## Issues
 
 If you have any problems with or questions about this image, please contact us

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,5 +1,10 @@
 # Elasticsearch Example
 
+## Running The experiment
+From `examples/elasticsearch` execute:
+
+`kubectl apply -k .`
+
 ## Introduction
 [Elasticsearch](https://github.com/elastic/elasticsearch) is a widely used distributed database often used as a search engine or for logging. In this example, we demonstrate how to tune Elasticsearch using the benchmarking tool [Rally](https://esrally.readthedocs.io/en/stable/). Rally provides a variety of datasets, called tracks, that can be used to load test Elasticsearch. For each track there are several challenges, designed to test different workloads. This example shows how to i) use a setupTask to integrate with a Helm chart, ii) tune JVM parameters alongside the Kubernetes resources, and iii) set a maximum length a trial can run before being considered failed.
 

--- a/hpa/README.md
+++ b/hpa/README.md
@@ -5,7 +5,7 @@
 Run
 `redskyctl generate rbac -f experiment.yaml | kubectl apply -f -`
 and then
-`kustomize build . | kubect apply -n <my-namespace> -f -`
+`kubect apply -n <my-namespace> -k .`
 
 
 ## Introduction
@@ -17,7 +17,5 @@ We show how to define such stormforge optimization experiment using two load tes
 ## Prerequisites
 
 You must have a Kubernetes cluster. We recommend using a cluster with 4 nodes, 16 vCPUs (4 on each node) and 32GB of memory (8 on each node). Additionally, you will need a local configured copy of `kubectl`.
-
-A local install of [Kustomize](https://github.com/kubernetes-sigs/kustomize/releases) (v3.1.0+) is required to manage the objects in you cluster.
 
 Additionally, you will need a local configured copy of `kubectl` and to initialize StormForge Optimize in your cluster. You can download a binary for your platform from the [installation guide](https://docs.stormforge.io/getting-started/install/) and run `redskyctl init` (while connected to your cluster).

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -1,13 +1,16 @@
 # JVM Example
 
+## Running The Experiment
+From the `examples/jvm` directory run:
+
+`kubectl apply -k .`
+
 ## Introduction
 The Java Virtual Machine(JVM) is a widely used portable execution environment for running java-based applications. In this example, we demonstrate how to tune the JVM using the benchmarking suite [Renaissance](https://github.com/renaissance-benchmarks/renaissance/). Renaissance provides a variety of benchmarks that can be used to load test many aspects of the JVM such as just-in-time compilers, interpreters, and garbage collectors. This example shows how to i) patch individual trials and ii) tune JVM parameters alongside the Kubernetes resources.
 
 ## Prerequisites
 
-You must have a Kubernetes cluster. We recommend using a cluster with 2 nodes, 8vCPUs (4 on each node) and 16GB of memory (8 on each node).
-
-A local install of [Kustomize](https://github.com/kubernetes-sigs/kustomize/releases) (v3.1.0+) is required to manage the objects in you cluster.
+You must have a Kubernetes cluster. We recommend using a cluster with at least 1 node with 4vCPUs and 8GB of memory.
 
 Additionally, you will need a local configured copy of `kubectl` and to initialize StormForge Optimize v1.6.0 or later in your cluster. You can download a binary for your platform from the [installation guide](https://docs.stormforge.io/getting-started/install/) and run `redskyctl init` (while connected to your cluster).
 
@@ -27,7 +30,6 @@ The resources for this tutorial can be found in the [`/jvm/`](https://github.com
 * `docker-entrypoint.sh`
 : A shell file that defines the docker configuration. The JAVA OPTS parameters get applied in this file.
 
-To run the experiment use `kustomize build | kubectl apply -f -`.
 
 ## Experiment Lifecycle
 

--- a/parallel-trials/README.md
+++ b/parallel-trials/README.md
@@ -5,7 +5,7 @@ In this example, we demonstrate how to speed up optimization of the postgres exa
 The application optimized in this example is the same as in the postgres example and the manifests defining the application are in the [examples/postgres](https://github.com/thestormforge/examples/tree/master/postgres) folder. The experiment definition is the same as the postgres example, except that multiple trials are run in parallel. To launch the experiment run
 
 ```
-kustomize build | kubectl apply -f -
+kubectl apply -k .
 ```
 
 This will create four namespaces with labels matching the `namespaceSelector` in the experiment.yaml file, launch the application into each namespace, and then create the experiment. You should see the same lifecycle observed in the postgres example in each individual namespace.

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,5 +1,10 @@
 # Postgres Example
 
+## Running The Experiment
+From the `examples/postgres` directory run:
+
+`kubectl apply -k .`
+
 ## Introduction
 [PostgreSQL](https://www.postgresql.org/) is a widely used open-source database management system. Utilized either as a standalone database, or as a component of larger systems, Postgres can be used to manage anything from simple application logs to massive datasets.
 
@@ -8,8 +13,6 @@ In this example, we demonstrate how one can effectively and efficiently tune Pos
 ## Prerequisites
 
 You must have a Kubernetes cluster. While this example will run on Minikube, we highly recommend using a cluster with 2 nodes, 8vCPUs (4 on each node) and 16GB of memory (8 on each node). Additionally, you will need a local configured copy of `kubectl`.
-
-A local install of [Kustomize](https://github.com/kubernetes-sigs/kustomize/releases) (v3.1.0+) is required to manage the objects in you cluster.
 
 Additionally, you will need a local configured copy of `kubectl` and to initialize StormForge Optimize in your cluster. You can download a binary for your platform from the [installation guide](https://docs.stormforge.io/getting-started/install/) and run `redskyctl init` (while connected to your cluster).
 ## Example Resources

--- a/voting-webapp/README.md
+++ b/voting-webapp/README.md
@@ -1,5 +1,10 @@
 # Web App Example
 
+## Running The Experiment
+From `examples/voting-webapp` execute
+
+`kubectl apply -k .`
+
 ## Introduction
 A simple distributed application based on the official Docker [voting app](https://github.com/dockersamples/example-voting-app).
 This application allows users to vote on "cats" vs. "dogs", and serves the results in a simple web page.
@@ -19,8 +24,6 @@ In this example, we demonstrate how to tune a typical application with several c
 ## Prerequisites
 
 You must have a Kubernetes cluster. We recommend using a cluster with 4 nodes, 16 vCPUs (4 on each node) and 32GB of memory (8 on each node). Additionally, you will need a local configured copy of `kubectl`.
-
-A local install of [Kustomize](https://github.com/kubernetes-sigs/kustomize/releases) (v3.1.0+) is required to manage the objects in you cluster.
 
 Additionally, you will need a local configured copy of `kubectl` and to initialize StormForge Optimize in your cluster. You can download a binary for your platform from the [installation guide](https://docs.stormforge.io/getting-started/install/) and run `redskyctl init` (while connected to your cluster).
 


### PR DESCRIPTION
I tested `kubectl apply -k` with the jvm, and assumed it should work out with the rest. I can start testing the rest of them. Not sure if we need to document which version of kubectl has kustomize built into it.