### PR TITLE
refactor: Refactor postgres example to use upstream pg container

### DIFF
--- a/postgres/application.yaml
+++ b/postgres/application.yaml
@@ -17,13 +17,36 @@ scenarios:
     initialDelaySeconds: 15
     podTemplate:
       spec:
-        containers:
-        - name: pgbench
-          image: crunchydata/crunchy-pgbench:centos7-11.4-2.4.1
+        initContainers:
+        - name: pgbench-initialize
+          image: postgres:11.1-alpine
           envFrom:
           - secretRef:
               name: postgres-secret
-
+          command:
+          - /usr/local/bin/pgbench
+          args:
+          - --initialize
+          - --host=$(PG_HOSTNAME)
+          - --username=$(PG_USERNAME)
+          - --scale=$(PGBENCH_SCALE)
+          - $(PG_DATABASE)
+        containers:
+        - name: pgbench
+          image: postgres:11.1-alpine
+          envFrom:
+          - secretRef:
+              name: postgres-secret
+          command:
+          - /usr/local/bin/pgbench
+          args:
+          - --client=$(PGBENCH_CLIENTS)
+          - --jobs=$(PGBENCH_JOBS)
+          - --scale=$(PGBENCH_SCALE)
+          - --transactions=$(PGBENCH_TRANSACTIONS)
+          - --host=$(PG_HOSTNAME)
+          - --username=$(PG_USERNAME)
+          - $(PG_DATABASE)
 objectives:
 - goals:
   - name: duration

--- a/postgres/postgres.yaml
+++ b/postgres/postgres.yaml
@@ -6,13 +6,14 @@ metadata:
     app.kubernetes.io/instance: postgres-stormforge-example
     app.kubernetes.io/name: postgres
 stringData:
-  PGBENCH_CLIENTS: "1"
-  PGBENCH_JOBS: "1"
+  PGBENCH_CLIENTS: "5"
+  PGBENCH_JOBS: "10"
   PGBENCH_SCALE: "20"
-  PGBENCH_TRANSACTIONS: "1"
+  PGBENCH_TRANSACTIONS: "10000"
   PG_DATABASE: "test_db"
   PG_HOSTNAME: "postgres"
   PG_PASSWORD: "test_password"
+  PGPASSWORD: "test_password"
   PG_USERNAME: "test_user"
 ---
 apiVersion: v1


### PR DESCRIPTION
With some recent changes upstream, the crunchydata pgbench container no longer
is available. Turns out, we dont actually need it. Upstream postgres includes
pgbench so we can use this directly and simplify the experiment dependencies.

This also tweaks the pgbench settings so that the run is a little longer ( approx 30s/trial on my laptop ). 

Signed-off-by: Brad Beam <brad.beam@stormforge.io>