### PR TITLE
Build images

### DIFF
--- a/.github/workflows/jvm.yaml
+++ b/.github/workflows/jvm.yaml
@@ -1,0 +1,47 @@
+name: JVM Image
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+    - main
+    paths:
+    - 'jvm/docker-entrypoint.sh'
+    - 'jvm/Dockerfile'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository }}-jvm
+        flavor: |
+          latest=true
+        tags: |
+          type=sha
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./jvm
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/results_exporter.yaml
+++ b/.github/workflows/results_exporter.yaml
@@ -1,0 +1,46 @@
+name: Results Exporter Image
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+    - main
+    paths:
+    - 'voting-webapp/results-exporter/**'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository }}-results-exporter
+        flavor: |
+          latest=true
+        tags: |
+          type=sha
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./voting-webapp/results-exporter
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/jvm/.dockerignore
+++ b/jvm/.dockerignore
@@ -1,0 +1,2 @@
+**
+!/docker-entrypoint.sh

--- a/jvm/experiment.yaml
+++ b/jvm/experiment.yaml
@@ -71,5 +71,5 @@ spec:
               activeDeadlineSeconds: 1800
               containers:
               - args: ["reactors"]
-                image: gcr.io/redskyops/renaissance:0.10.0
+                image: ghcr.io/thestormforge/examples-jvm
                 name: renaissance

--- a/voting-webapp/application/results-exporter.yaml
+++ b/voting-webapp/application/results-exporter.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: result-exporter
-        image: gcr.io/redskyops/result-exporter:1.1.0
+        image: ghcr.io/thestormforge/examples-results-exporter
         env:
         - name: DB_HOST
           value: db

--- a/voting-webapp/results-exporter/.dockerignore
+++ b/voting-webapp/results-exporter/.dockerignore
@@ -1,2 +1,3 @@
-.venv
-.idea
+**
+!/app.py
+!/requirements.txt


### PR DESCRIPTION
This PR introduces two new GitHub Actions workflows for building and pushing the images required for the examples. The workflow can be triggered manually through the GitHub UI, but will also be triggered automatically if any of the files in the Docker context are changed in Git (only if those files are changed on `main`).

The images will be pushed into the GitHub Container Registry using the repo name ("examples-") as a prefix. For tagging: every image will be tagged with the short Git commit. Additionally, each time we push images, the most recent push will get the `latest` tag. The K8s manifests have been updated to omit an explicit tag so they will always pick up `latest` (this solves the problem of needing to update the manifests in Git each time we push images).