### PR TITLE
Drop optional labels stormforge.io/application and stormforge.io/scenario

### DIFF
--- a/cassandra/cassandra-full-experiment.yaml
+++ b/cassandra/cassandra-full-experiment.yaml
@@ -3,9 +3,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: cassandra-rwx
-  labels:
-    stormforge.io/application: 'cassandra-rwx'
-    stormforge.io/scenario: 'cassandra-stress'
   annotations:
     config.kubernetes.io/path: 'cassandra-full-experiment.yaml'
 spec:

--- a/elasticsearch/experiment.yaml
+++ b/elasticsearch/experiment.yaml
@@ -3,9 +3,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: elasticsearch-example
-  labels:
-    stormforge.io/application: 'elasticsearch'
-    stormforge.io/scenario: 'rally'
   annotations:
     config.kubernetes.io/path: 'experiment.yaml'
 spec:

--- a/hello-world/hello-world-101-experiment.yaml
+++ b/hello-world/hello-world-101-experiment.yaml
@@ -20,11 +20,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: hello-world-101
-  labels:
-    # These labels are required. They help StormForge organize the experiment
-    # in the web UI.
-    stormforge.io/application: 'hello-world'
-    stormforge.io/scenario: 'example'
 
 spec:
   # The optimization section lets you configure optional behavior adjustments
@@ -65,29 +60,13 @@ spec:
   # choosing new parameter values, and before collecting the metric results.
   # The primary component of each trial is a k8s Job.
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'hello-world'
-        stormforge.io/scenario: 'example'
     spec:
       # The jobTemplate is used to create the trial Job. It follows the usual
       # semantics of a k8s Job definition.
       jobTemplate:
-        metadata:
-          labels:
-            # For ease of observation, these labels should match the
-            # experiments own corresponding labels.
-            stormforge.io/application: 'hello-world'
-            stormforge.io/scenario: 'example'
         spec:
           backoffLimit: 1
           template:
-            metadata:
-              labels:
-                # For ease of observation, these labels should match the
-                # experiments own corresponding labels.
-                stormforge.io/application: 'hello-world'
-                stormforge.io/scenario: 'example'
             spec:
               activeDeadlineSeconds: 600 # Running longer than 10min is a failure
               restartPolicy: Never

--- a/hello-world/hello-world-102-experiment.yaml
+++ b/hello-world/hello-world-102-experiment.yaml
@@ -27,9 +27,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: hello-world-102
-  labels:
-    stormforge.io/application: 'hello-world'
-    stormforge.io/scenario: 'example'
   annotations:
     config.kubernetes.io/path: 'hello-world-102-experiment.yaml'
 spec:
@@ -68,10 +65,6 @@ spec:
     query: 'scalar( output{job="trialRun", instance="{{ .Trial.Name }}"} )'
 
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'hello-world'
-        stormforge.io/scenario: 'example'
     spec:
       # setupTasks are builtin helpers which can make trials easier to run.
       #
@@ -85,17 +78,9 @@ spec:
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
 
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: 'hello-world'
-            stormforge.io/scenario: 'example'
         spec:
           backoffLimit: 1
           template:
-            metadata:
-              labels:
-                stormforge.io/application: 'hello-world'
-                stormforge.io/scenario: 'example'
             spec:
               activeDeadlineSeconds: 60
               restartPolicy: Never

--- a/hello-world/hello-world-102-resources.yaml
+++ b/hello-world/hello-world-102-resources.yaml
@@ -3,8 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: optimize-pro-setuptask-crb
-  labels:
-    stormforge.io/application: 'hello-world'
 roleRef:
   name: optimize-pro-setuptask-cr
   kind: ClusterRole
@@ -19,15 +17,11 @@ kind: ServiceAccount
 metadata:
   name: optimize-pro-setuptask-sa
   namespace: default # ENSURE SAME VALUE AS CLUSTER_ROLE_BINDING
-  labels:
-    stormforge.io/application: 'hello-world'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: optimize-pro-setuptask-cr
-  labels:
-    stormforge.io/application: 'hello-world'
 rules:
 - resources:
   - clusterroles

--- a/hello-world/hello-world-121-experiment.yaml
+++ b/hello-world/hello-world-121-experiment.yaml
@@ -27,9 +27,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: hello-world-121
-  labels:
-    stormforge.io/application: 'hello-world'
-    stormforge.io/scenario: 'example'
   annotations:
     config.kubernetes.io/path: 'hello-world-121-experiment.yaml'
 
@@ -72,10 +69,6 @@ spec:
                 value: "{{ .Values.trialInput }}"
 
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'hello-world'
-        stormforge.io/scenario: 'example'
     spec:
       readinessGates:
       - apiVersion: apps/v1
@@ -91,16 +84,8 @@ spec:
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
 
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: 'hello-world'
-            stormforge.io/scenario: 'example'
         spec:
           template:
-            metadata:
-              labels:
-                stormforge.io/application: 'hello-world'
-                stormforge.io/scenario: 'example'
             spec:
               activeDeadlineSeconds: 60
               restartPolicy: Never

--- a/hello-world/hello-world-121-resources.yaml
+++ b/hello-world/hello-world-121-resources.yaml
@@ -14,9 +14,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-world-121-nginx
-  labels:
-    app.kubernetes.io/name: hello-world-121-nginx
-    stormforge.io/application: 'hello-world'
 spec:
   replicas: 1
   selector:
@@ -39,8 +36,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: optimize-pro-setuptask-crb
-  labels:
-    stormforge.io/application: 'hello-world'
 roleRef:
   name: optimize-pro-setuptask-cr
   kind: ClusterRole
@@ -55,15 +50,11 @@ kind: ServiceAccount
 metadata:
   name: optimize-pro-setuptask-sa
   namespace: default # ENSURE SAME VALUE AS CLUSTER_ROLE_BINDING
-  labels:
-    stormforge.io/application: 'hello-world'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: optimize-pro-setuptask-cr
-  labels:
-    stormforge.io/application: 'hello-world'
 rules:
 - resources:
   - clusterroles

--- a/hpa/locust/experiment.yaml
+++ b/hpa/locust/experiment.yaml
@@ -3,9 +3,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: hpa-example
-  labels:
-    stormforge.io/application: 'hpa'
-    stormforge.io/scenario: 'locust'
   annotations:
     config.kubernetes.io/path: 'experiment.yaml'
 spec:

--- a/hpa/sf-perftest/sf-experiment/experiment.yaml
+++ b/hpa/sf-perftest/sf-experiment/experiment.yaml
@@ -3,9 +3,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: hpa-sf
-  labels:
-    stormforge.io/application: hpa-sf
-    stormforge.io/scenario: standard
   annotations:
     config.kubernetes.io/path: 'experiment.yaml'
 spec:
@@ -98,25 +95,13 @@ spec:
                   memory: '{{ .Values.memory }}M'
                   cpu: '{{ .Values.cpu }}m'
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: hpa-sf
-        stormforge.io/scenario: standard
     spec:
       setupTasks:
       - name: prometheus
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: hpa-sf
-            stormforge.io/scenario: standard
         spec:
           template:
-            metadata:
-              labels:
-                stormforge.io/application: hpa-sf
-                stormforge.io/scenario: standard
             spec:
               containers:
               - name: stormforger

--- a/java/pet-clinic/app/pet-clinic-lb.yaml
+++ b/java/pet-clinic/app/pet-clinic-lb.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pet-clinic-lb
+  namespace: pet-clinic
 spec:
   type: LoadBalancer
   selector:

--- a/java/pet-clinic/experiments/experiment-startup.yaml
+++ b/java/pet-clinic/experiments/experiment-startup.yaml
@@ -4,15 +4,11 @@ kind: Experiment
 metadata:
   name: pet-clinic-startup
   namespace: pet-clinic
-  labels:
-    stormforge.io/application: 'pet-clinic'
-    stormforge.io/objective: 'cost-vs-startup-time'
-    stormforge.io/scenario: 'pet-clinic-startup-time'
-    stormforge.io/source: 'logs-with-jvm-flags'
 spec:
   optimization:
   - name: "experimentBudget"
     value: "100"
+
   parameters:
   - name: cpu
     baseline: 500
@@ -38,6 +34,7 @@ spec:
     baseline: 500
     max: 1500
     min: 250
+
   metrics:
   - name: startup-time
     minimize: true
@@ -79,36 +76,13 @@ spec:
                 value: '-XX:+PreferContainerQuotaForCPUCount -XX:NewRatio={{ .Values.gc_newRatio }} -XX:SurvivorRatio={{ .Values.gc_survivorRatio }} -Xss{{ .Values.threadStackSize }}k -XX:InitialCodeCacheSize={{ .Values.initialCodeCacheSize }}k'
 
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'pet-clinic'
-        stormforge.io/objective: 'cost-vs-startup-time'
-        stormforge.io/scenario: 'pet-clinic-startup-time'
     spec:
-      readinessGates:
-      - selector:
-          matchLabels:
-            stormforge.io/application: 'pet-clinic'
-            stormforge.io/scenario: 'pet-clinic-startup-time'
-        failureThreshold: 60
-        conditionTypes:
-        - ContainersReady
       setupTasks:
       - name: prometheus
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: 'pet-clinic'
-            stormforge.io/objective: 'cost-vs-startup-time'
-            stormforge.io/scenario: 'pet-clinic-startup-time'
         spec:
           template:
-            metadata:
-              labels:
-                stormforge.io/application: 'pet-clinic'
-                stormforge.io/objective: 'cost-vs-startup-time'
-                stormforge.io/scenario: 'pet-clinic-startup-time'
             spec:
               serviceAccountName: pet-clinic-startup-setup
               containers:

--- a/jvm/experiment.yaml
+++ b/jvm/experiment.yaml
@@ -3,9 +3,6 @@ apiVersion: optimize.stormforge.io/v1beta2
 kind: Experiment
 metadata:
   name: jvm-reactors
-  labels:
-    stormforge.io/application: 'jvm-reactors'
-    stormforge.io/scenario: 'renaissance'
 
 spec:
   optimization:

--- a/neoload/README.md
+++ b/neoload/README.md
@@ -310,15 +310,10 @@ Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
 ...
 ```
 
-
 ```terminal
 $ kubectl describe trial neoload-1da099b3e4d7-001
 Name:         neoload-1da099b3e4d7-001
 Namespace:    default
-Labels:       stormforge.io/application=default
-              stormforge.io/experiment=neoload-1da099b3e4d7
-              stormforge.io/objective=default
-              stormforge.io/scenario=default
 Annotations:  stormforge.io/report-trial-url: https://api.stormforge.dev/v1/experiments/neoload-1da099b3e4d7/trials/1
 API Version:  optimize.stormforge.io/v1beta2
 Kind:         Trial
@@ -357,18 +352,10 @@ Metadata:
   Job Template:
     Metadata:
       Creation Timestamp:  2022-02-25T21:31:57Z
-      Labels:
-        stormforge.io/application:  default
-        stormforge.io/objective:    default
-        stormforge.io/scenario:     default
     Spec:
       Template:
         Metadata:
           Creation Timestamp:  2022-02-25T21:31:57Z
-          Labels:
-            stormforge.io/application:  default
-            stormforge.io/objective:    default
-            stormforge.io/scenario:     default
         Spec:
           Containers:
             Env:

--- a/neoload/experiment.yaml
+++ b/neoload/experiment.yaml
@@ -3,10 +3,6 @@ kind: Experiment
 metadata:
   name: neoload-UUID
   namespace: default
-  labels:
-    stormforge.io/application: 'default'
-    stormforge.io/objective: 'default'
-    stormforge.io/scenario: 'default'
 spec:
   optimization:
   - name: "experimentBudget"
@@ -177,28 +173,13 @@ spec:
                   memory: '{{ index .Values "deployment/worker/worker/resources/memory"
                     }}Mi'
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'default'
-        stormforge.io/objective: 'default'
-        stormforge.io/scenario: 'default'
     spec:
       setupTasks:
       - name: monitoring
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: 'default'
-            stormforge.io/objective: 'default'
-            stormforge.io/scenario: 'default'
         spec:
           template:
-            metadata:
-              labels:
-                stormforge.io/application: 'default'
-                stormforge.io/objective: 'default'
-                stormforge.io/scenario: 'default'
             spec:
               containers:
                 - name: neoload
@@ -234,8 +215,6 @@ kind: ConfigMap
 metadata:
   name: default-neoload
   namespace: default
-  labels:
-    stormforge.io/application: 'default'
 data:
   neoload-stormforge.yaml: |
     name: Stormforge Perf Test
@@ -285,7 +264,5 @@ kind: Secret
 metadata:
   name: neoload-token
   namespace: default
-  labels:
-    stormforge.io/application: 'default'
 data:
   token: XXX-XXX-XXX-XXX

--- a/postgres/experiment.yaml
+++ b/postgres/experiment.yaml
@@ -4,10 +4,6 @@ kind: Experiment
 metadata:
   name: postgres-experiment
   namespace: postgres
-  labels:
-    stormforge.io/application: 'postgres'
-    stormforge.io/objective: 'duration-vs-cost'
-    stormforge.io/scenario: 'pgbench'
 spec:
   optimization:
   - name: experimentBudget
@@ -54,25 +50,13 @@ spec:
                   memory: '{{ .Values.memory }}M'
   trialTemplate:
     metadata:
-      labels:
-        stormforge.io/application: 'postgres'
-        stormforge.io/objective: 'duration-vs-cost'
-        stormforge.io/scenario: 'pgbench'
     spec:
       initialDelaySeconds: 15
       jobTemplate:
         metadata:
-          labels:
-            stormforge.io/application: 'postgres'
-            stormforge.io/objective: 'duration-vs-cost'
-            stormforge.io/scenario: 'pgbench'
         spec:
           template:
             metadata:
-              labels:
-                stormforge.io/application: 'postgres'
-                stormforge.io/objective: 'duration-vs-cost'
-                stormforge.io/scenario: 'pgbench'
             spec:
               initContainers:
               - name: pgbench-initialize

--- a/sf-perftest-testapp/blazemeter-cloud/experiment.yaml
+++ b/sf-perftest-testapp/blazemeter-cloud/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: testapp-with-blazemeter-0
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/curl/experiment.yaml
+++ b/sf-perftest-testapp/curl/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: curl-testapp
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/jmeter/experiment.yaml
+++ b/sf-perftest-testapp/jmeter/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: jmeter-testapp
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/k6/experiment.yaml
+++ b/sf-perftest-testapp/k6/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: testapp-with-k6-alpha-2022-0
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/locust/experiment.yaml
+++ b/sf-perftest-testapp/locust/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: locust-testapp
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/neoload/experiment-rbac.yaml
+++ b/sf-perftest-testapp/neoload/experiment-rbac.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: testapp-with-neoload-0
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/neoload/experiment.yaml
+++ b/sf-perftest-testapp/neoload/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: testapp-with-neoload-0
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/sf-perftest-testapp/sf-perftest/experiment.yaml
+++ b/sf-perftest-testapp/sf-perftest/experiment.yaml
@@ -4,9 +4,6 @@ kind: Experiment
 metadata:
   name: testapp-with-cli-v3-2022-4
   namespace: default
-  labels:
-    stormforge.io/application: 'stormforger-testapp'
-    stormforge.io/scenario: 'scenario1'
 spec:
   optimization:
   - name: experimentBudget

--- a/webapp/hipster-shop/application/README.md
+++ b/webapp/hipster-shop/application/README.md
@@ -1,6 +1,7 @@
 # Hipster Shop / Online Boutique Example
 
 ## Introduction
+
 The [Online Boutique](https://github.com/GoogleCloudPlatform/microservices-demo) (also known as the Hipster Shop) is a microservices demo application from Google.
 It consists of 11 microservices that together implement a web-based ecommerce shop with products that a user can browse, add to a shopping cart, and purchase.
 
@@ -15,27 +16,27 @@ kubectl apply -f /manifests/manifests.yaml
 Note: This command will deploy the application to whichever namespace is selected in your current `kubectl` context.
 
 ## Architecture
+
 From the Google Online Boutiqe documentation:
 
 | Service                                              | Language      | Description                                                                                                                       |
 | ---------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [frontend](./src/frontend)                           | Go            | Exposes an HTTP server to serve the website. Does not require signup/login and generates session IDs for all users automatically. |
-| [cartservice](./src/cartservice)                     | C#            | Stores the items in the user's shopping cart in Redis and retrieves it.                                                           |
-| [productcatalogservice](./src/productcatalogservice) | Go            | Provides the list of products from a JSON file and ability to search products and get individual products.                        |
-| [currencyservice](./src/currencyservice)             | Node.js       | Converts one money amount to another currency. Uses real values fetched from European Central Bank. It's the highest QPS service. |
-| [paymentservice](./src/paymentservice)               | Node.js       | Charges the given credit card info (mock) with the given amount and returns a transaction ID.                                     |
-| [shippingservice](./src/shippingservice)             | Go            | Gives shipping cost estimates based on the shopping cart. Ships items to the given address (mock)                                 |
-| [emailservice](./src/emailservice)                   | Python        | Sends users an order confirmation email (mock).                                                                                   |
-| [checkoutservice](./src/checkoutservice)             | Go            | Retrieves user cart, prepares order and orchestrates the payment, shipping and the email notification.                            |
-| [recommendationservice](./src/recommendationservice) | Python        | Recommends other products based on what's given in the cart.                                                                      |
-| [adservice](./src/adservice)                         | Java          | Provides text ads based on given context words.                                                                                   |
+| [frontend](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/frontend)                           | Go            | Exposes an HTTP server to serve the website. Does not require signup/login and generates session IDs for all users automatically. |
+| [cartservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/cartservice)                     | C#            | Stores the items in the user's shopping cart in Redis and retrieves it.                                                           |
+| [productcatalogservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/productcatalogservice) | Go            | Provides the list of products from a JSON file and ability to search products and get individual products.                        |
+| [currencyservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/currencyservice)             | Node.js       | Converts one money amount to another currency. Uses real values fetched from European Central Bank. It's the highest QPS service. |
+| [paymentservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/paymentservice)               | Node.js       | Charges the given credit card info (mock) with the given amount and returns a transaction ID.                                     |
+| [shippingservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/shippingservice)             | Go            | Gives shipping cost estimates based on the shopping cart. Ships items to the given address (mock)                                 |
+| [emailservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/emailservice)                   | Python        | Sends users an order confirmation email (mock).                                                                                   |
+| [checkoutservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/checkoutservice)             | Go            | Retrieves user cart, prepares order and orchestrates the payment, shipping and the email notification.                            |
+| [recommendationservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/recommendationservice) | Python        | Recommends other products based on what's given in the cart.                                                                      |
+| [adservice](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/src/adservice)                         | Java          | Provides text ads based on given context words.                                                                                   |
 
 ![Architecture diagram](architecture-diagram.png)
 
 ## Resources
 
-The resources in this directory can be used to launch an Online Boutique instance in your Kubernetes cluster. 
+The resources in this directory can be used to launch an Online Boutique instance in your Kubernetes cluster.
 All of the manifests are combined into a single YAML file `manifests.yaml` in the `manifests/` folder.
 
 More information and other versions of the Online Boutique manifests can be found at the [official Online Boutique repo](https://github.com/GoogleCloudPlatform/microservices-demo).
-

--- a/webapp/hipster-shop/k6/experiment.yaml
+++ b/webapp/hipster-shop/k6/experiment.yaml
@@ -4,10 +4,6 @@ kind: Experiment
 metadata:
   name: k6-hipster-demo-1
   namespace: hipster-demo
-  labels:
-    stormforge.io/application: 'k6-hipster-demo'
-    stormforge.io/objective: 'cost-vs-p95-latency'
-    stormforge.io/scenario: 'constant-arrival-rate'
   annotations:
     config.kubernetes.io/path: 'experiment.yaml'
 
@@ -83,11 +79,6 @@ spec:
         replicas: {{ index .Values "deployment/frontend/replicas" }}
   
   trialTemplate:
-    metadata:
-      labels:
-        stormforge.io/application: 'k6-hipster-demo'
-        stormforge.io/objective: 'cost-vs-p95-latency'
-        stormforge.io/scenario: 'constant-arrival-rate'
     spec:
       initialDelaySeconds: 15
       setupServiceAccountName: optimize-setup-810861
@@ -95,18 +86,8 @@ spec:
       - name: prometheus
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
       jobTemplate:
-        metadata:
-          labels:
-            stormforge.io/application: 'k6-hipster-demo'
-            stormforge.io/objective: 'cost-vs-p95-latency'
-            stormforge.io/scenario: 'constant-arrival-rate'
         spec:
           template:
-            metadata:
-              labels:
-                stormforge.io/application: 'k6-hipster-demo'
-                stormforge.io/objective: 'cost-vs-p95-latency'
-                stormforge.io/scenario: 'constant-arrival-rate'
             spec:
               containers:
               - name: constant-arrival-rate
@@ -120,15 +101,11 @@ kind: ServiceAccount
 metadata:
   name: optimize-setup-810861
   namespace: hipster-demo
-  labels:
-    stormforge.io/application: 'k6-hipster-demo'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: optimize-prometheus-810861
-  labels:
-    stormforge.io/application: 'k6-hipster-demo'
 rules:
 - resources:
   - clusterroles
@@ -182,8 +159,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: optimize-setup-prometheus-810861
-  labels:
-    stormforge.io/application: 'k6-hipster-demo'
 roleRef:
   name: optimize-prometheus-810861
   kind: ClusterRole

--- a/webapp/voting-webapp/locust/experiment.yaml
+++ b/webapp/voting-webapp/locust/experiment.yaml
@@ -4,10 +4,6 @@ kind: Experiment
 metadata:
   name: webapp-locust-metrics-experiment
   namespace: default
-  labels:
-    stormforge.io/application: 'votingapp'
-    stormforge.io/objective: 'default'
-    stormforge.io/scenario: '100-clients'
   annotations:
     config.kubernetes.io/path: 'experiment.yaml'
 spec:
@@ -70,10 +66,6 @@ spec:
                   memory: '{{ .Values.voting_service_memory }}Mi'
   trialTemplate:
     metadata:
-      labels:
-        stormforge.io/application: 'votingapp'
-        stormforge.io/objective: 'default'
-        stormforge.io/scenario: '100-clients'
     spec:
       setupServiceAccountName: optimize-setup-f19e28
       setupTasks:
@@ -81,17 +73,9 @@ spec:
         helmChart: oci://registry.stormforge.io/optimize-pro/prometheus
       jobTemplate:
         metadata:
-          labels:
-            stormforge.io/application: 'votingapp'
-            stormforge.io/objective: 'default'
-            stormforge.io/scenario: '100-clients'
         spec:
           template:
             metadata:
-              labels:
-                stormforge.io/application: 'votingapp'
-                stormforge.io/objective: 'default'
-                stormforge.io/scenario: '100-clients'
             spec:
               containers:
               - name: 100-clients
@@ -117,8 +101,6 @@ kind: ConfigMap
 metadata:
   name: 100-clients-locustfile-f19e28
   namespace: default
-  labels:
-    stormforge.io/application: 'votingapp'
 data:
   locustfile.py: |
     import os
@@ -146,15 +128,11 @@ kind: ServiceAccount
 metadata:
   name: optimize-setup-f19e28
   namespace: default
-  labels:
-    stormforge.io/application: 'votingapp'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: optimize-prometheus-f19e28
-  labels:
-    stormforge.io/application: 'votingapp'
 rules:
 - resources:
   - clusterroles
@@ -208,8 +186,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: optimize-setup-prometheus-f19e28
-  labels:
-    stormforge.io/application: 'votingapp'
 roleRef:
   name: optimize-prometheus-f19e28
   kind: ClusterRole


### PR DESCRIPTION
We are currently planning to drop the following required labels for Optimize Pro experiments:

* `stormforge.io/application`
* `stormforge.io/scenario`

These labels are currently still required by our API, but not used/shown in the webui anymore. Since they are only required by our StormForge API (the controller being unaware of this), we can drop them from the examples when the API does not require them anymore.

This also fixes a few other things:

* hipster-shop: Links in the README now point to the google repo
* pet-clinic: The namespace is now set for the pet-clinic LB manifest
* pet-clinic: Drop readinessGate as no containers with those labels existed anyway
* Drop usage of `stormforge.io/objective` which is not required nor used for some time